### PR TITLE
Retry request if request fails because of forbidden redirect

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,11 +12,23 @@ class Service
   end
 
   def down?
-    document = Nokogiri::HTML(open(url))
-    document.css('.page-status').text.include?('All Systems Operational') == false
+    !fetch_document.css('.page-status').text.include?('All Systems Operational')
   end
 
   def to_hash
     { id: id, name: name, url: url }
+  end
+
+  private
+
+  def fetch_document
+    Nokogiri::HTML(open(url))
+  rescue RuntimeError => error
+    if error.message.include? 'redirection forbidden'
+      url = error[/-> (.*$)/, 1]
+      Nokogiri::HTML(open(url))
+    else
+      raise
+    end
   end
 end


### PR DESCRIPTION
Jobs are failing because of forbidden redirects. This change should avoid the failure and retry the request with the correct URL.

![screenshot 2015-02-11 12 24 48](https://cloud.githubusercontent.com/assets/154463/6155544/fe384026-b1e8-11e4-9c32-9fcf18ee3d35.png)
